### PR TITLE
[ECS-17] fix: Remove unused import and reorder blog routes in publicRoutes.js

### DIFF
--- a/src/routes/publicRoutes.js
+++ b/src/routes/publicRoutes.js
@@ -29,7 +29,6 @@ import BlogIndex from "../routes/BlogIndex";
 import LegalDisclaimer from "../components/policies/LegalDisclaimer";
 import VerifyEmail from "../features/users/VerifyEmail";
 import FirstUserRegister from "../features/users/FirstUserRegister";
-import { Component } from "react";
 import ConnectExternalSystemsTest from "../features/reports/ptrs/ConnectExternalSystemsTest";
 
 export const publicRoutes = [
@@ -49,6 +48,14 @@ export const publicRoutes = [
   {
     path: "contact",
     Component: Contact,
+  },
+  {
+    path: "blog/:slug",
+    Component: StaticPageViewer,
+  },
+  {
+    path: "blog",
+    Component: BlogIndex,
   },
   {
     path: "thankyou-contact",


### PR DESCRIPTION
ECS-17 #comment Auto-linked commit
ECS-17 #transition Resolved